### PR TITLE
Bug fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Click Add Package.
 .bottomSheet(isPresented: $showCustomSheet) {
 // Sheet content goes here
 }
-  .detentsPresentation(detents: [.small, .medium, .large]) // configure sheeet detents
+  .detentsPresentation(detents: [.small, .medium, .large]) // configure sheet detents
   .ignoresSafeAreaEdgesPresentation(nil) // configure safe area edges to ignore
-  .dragIndicatorPresentation(isVisible: true) // display draag indicator
+  .dragIndicatorPresentation(isVisible: true) // display drag indicator
 ```
 
 # Modifiers

--- a/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+detentsPresentation.swift
+++ b/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+detentsPresentation.swift
@@ -8,8 +8,11 @@
 import SwiftUI
 
 public extension BottomSheet {
-    func detentsPresentation(detents: [Detent]) -> BottomSheet {
-        self.configuration.detents = detents
+    func detentsPresentation(initialDetent: Detent? = nil, detents: [Detent]) -> BottomSheet {
+        configuration.detents = detents
+        if let initialDetent = initialDetent ?? detents.smallest, !configuration.setInitialDetent {
+            configuration.selectedDetent = initialDetent
+        }
         return self
     }
  }

--- a/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+ignoresSafeAreaEdgesPresentation.swift
+++ b/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+ignoresSafeAreaEdgesPresentation.swift
@@ -9,26 +9,7 @@ import SwiftUI
 
 public extension BottomSheet {    
     func ignoresSafeAreaEdgesPresentation(_ edges: Edge.Set?) -> BottomSheet {
-        self.configuration.ignoredEdges = edges
+        self.configuration.ignoredEdges = edges ?? []
         return self
-    }
-}
-
-extension BottomSheetView {
-    func ignoresSafeAreaEdges(_ edges: Edge.Set?) -> some View{
-        self.modifier(IgnoresSafeAreaModifier(edges: edges))
-    }
-}
-
-struct IgnoresSafeAreaModifier: ViewModifier {
-    var edges: Edge.Set?
-    
-    func body(content: Content) -> some View {
-        if let edges {
-            content
-                .ignoresSafeArea(edges: edges)
-        } else {
-            content
-        }
     }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -85,7 +85,7 @@ struct BottomSheetView<Content: View>: View {
             .onAppear {
                 sheetHeight = configuration.selectedDetent.fraction * screenHeight
             }
-        }
+        }.ignoresSafeArea(edges: configuration.ignoredEdges)
     }
 }
 

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -7,16 +7,17 @@
 
 import SwiftUI
 
-struct BottomSheetView<Content:View>: View {
+struct BottomSheetView<Content: View>: View {
     @State private var sheetHeight: CGFloat = 0.0
     @State private var isNegativeScrollOffset = false
-    @ViewBuilder private let content: () -> Content
+
+    @Binding private var configuration: BottomSheetViewConfiguration
+
+    private let content: Content
     
-    internal var configuration: BottomSheetViewConfiguration
-    
-    init(configuration: BottomSheetViewConfiguration, content: @escaping () -> Content) {
+    init(configuration: Binding<BottomSheetViewConfiguration>, content: Content) {
+        self._configuration = configuration
         self.content = content
-        self.configuration = configuration
     }
     
     private var dragIndicator: some View {
@@ -37,88 +38,106 @@ struct BottomSheetView<Content:View>: View {
             VStack {
                 Spacer()
                 
-                ZStack {
-                    content()
-                    // Describe scroll behaviour if content is wrapped with ScrollView
-                        .scrollDisabled(isMaxDetentReached(screenHeight))
-                        .onScrollGeometryChange(for: Double.self, of: { geometry in
-                            return geometry.contentOffset.y
-                        }, action: { oldValue, newValue in
-                            print(newValue)
-                            
-                            if newValue < 0.0 {
-                                sheetHeight = sheetHeight + newValue
-                            }
-                            
-                            isNegativeScrollOffset = newValue < 0.0
-                        })
-                    
-                    if configuration.dragIndicator.isPresented {
-                        dragIndicator
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: sheetHeight)
-                .background(configuration.sheetColor)
-                .clipShape(
-                    .rect(
-                        topLeadingRadius: 20,
-                        bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0,
-                        topTrailingRadius: 20
-                    )
-                )
-                .shadow(radius: 10)
-                .animation(.easeInOut, value: sheetHeight)
-                .gesture(
-                    DragGesture()
-                        .onChanged { gesture in
-                            dragGestureOnChanged(gesture, screenHeight: screenHeight)
+                content
+                // Disable scroll behavior if content is wrapped with ScrollView
+                    .scrollDisabled(isMaxDetentReached(screenHeight))
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        return geometry.contentOffset.y
+                    } action: { oldValue, newValue in
+                        print(newValue)
+                        if newValue < 0.0 {
+                            sheetHeight = max(
+                                minHeight(for: screenHeight),
+                                sheetHeight + newValue
+                            )
                         }
-                        .onEnded({ gesture in
-                            dragGestureOnEnded(gesture, screenHeight: screenHeight)
-                        })
-                )
+                        
+                        isNegativeScrollOffset = newValue < 0.0
+                    }
+                    .overlay(content: {
+                        if configuration.dragIndicator.isPresented {
+                            dragIndicator
+                        }
+                    })
+                    .frame(maxWidth: .infinity)
+                    .frame(height: sheetHeight)
+                    .background(configuration.sheetColor)
+                    .clipShape(
+                        .rect(
+                            topLeadingRadius: configuration.cornerRadius,
+                            bottomLeadingRadius: 0,
+                            bottomTrailingRadius: 0,
+                            topTrailingRadius: configuration.cornerRadius
+                        )
+                    )
+                    .shadow(radius: 10)
+                    .animation(.easeInOut, value: sheetHeight)
+                    .gesture(
+                        DragGesture()
+                            .onChanged({ gesture in
+                                dragGestureOnChanged(gesture, screenHeight: screenHeight)
+                            })
+                            .onEnded({ gesture in
+                                dragGestureOnEnded(gesture, screenHeight: screenHeight)
+                            })
+                    )
             }
             .onAppear {
-                onAppear(screenHeight: screenHeight)
+                sheetHeight = configuration.selectedDetent.fraction * screenHeight
             }
         }
     }
 }
 
-private extension BottomSheetView {
+extension BottomSheetView {
+
+    var maxFraction: CGFloat {
+        configuration.detents.map(\.fraction).max() ?? 0.0
+    }
+
+    var minFraction: CGFloat {
+        configuration.detents.map(\.fraction).min() ?? 1.0
+    }
+
     func isMaxDetentReached(_ screenHeight: CGFloat) -> Bool {
-        let maxFraction = configuration.detents.map(\.fraction).max() ?? 0.0
-        
         if isNegativeScrollOffset == true {
             return true
         }
-        
-        if (screenHeight * maxFraction).rounded() <= sheetHeight.rounded() {
-            return false
-        } else {
-            return true
-        }
+
+        return (screenHeight * maxFraction).rounded() > sheetHeight.rounded()
     }
     
     func dragGestureOnChanged(_ gesture: DragGesture.Value, screenHeight: CGFloat) {
         let offset = gesture.translation
-        let newSheetHeight = sheetHeight - offset.height.rounded()
+        let desiredHeight = sheetHeight - offset.height.rounded()
         
-        if newSheetHeight > (configuration.detents.map(\.fraction).max() ?? 0.0) * screenHeight {
+        if desiredHeight > maxFraction * screenHeight {
             return
         }
         
-        sheetHeight = newSheetHeight
+        sheetHeight = max(
+            minHeight(for: screenHeight),
+            desiredHeight
+        )
     }
     
     func dragGestureOnEnded(_ gesture: DragGesture.Value, screenHeight: CGFloat) {
-        let detent = Detent.forValue(sheetHeight / screenHeight, from: configuration.detents)
-        sheetHeight = screenHeight * detent.fraction
+        let selectedDetent = Detent.forValue(
+            sheetHeight / screenHeight,
+            from: configuration.detents
+        )
+
+        let desiredHeight = screenHeight * selectedDetent.fraction
+
+        if desiredHeight < minHeight(for: screenHeight) {
+            return
+        }
+
+        configuration.selectedDetent = selectedDetent
+        sheetHeight = desiredHeight
     }
-    
-    func onAppear(screenHeight: CGFloat) {
-        sheetHeight = (configuration.detents.map(\.fraction).min() ?? 1.0) * screenHeight
+
+    func minHeight(for screenHeight: CGFloat) -> CGFloat {
+        minFraction * screenHeight
     }
 }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
@@ -15,14 +15,14 @@ class BottomSheetViewConfiguration {
     var detents: [Detent]
     var cornerRadius: CGFloat
     /// Edges that ignore the safe area
-    var ignoredEdges: Edge.Set?
+    var ignoredEdges: Edge.Set
     
     init(
         sheetColor: Color? = nil,
         dragIndicator: DragIndicator = .init(),
         detents: [Detent] = [.large],
         cornerRadius: CGFloat = 20,
-        ignoredEdges: Edge.Set? = .bottom
+        ignoredEdges: Edge.Set = []
     ) {
         self.sheetColor = sheetColor
         self.dragIndicator = dragIndicator

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
@@ -7,20 +7,42 @@
 
 import SwiftUI
 
+@Observable
 class BottomSheetViewConfiguration {
-    var sheetColor: Color
+    var sheetColor: Color?
     var dragIndicator: DragIndicator
+    var selectedDetent: Detent
     var detents: [Detent]
+    var cornerRadius: CGFloat
+    /// Edges that ignore the safe area
     var ignoredEdges: Edge.Set?
     
-    init(sheetColor: Color = .white,
-         dragIndicator: DragIndicator = .init(),
-         detents: [Detent] = [.large],
-         ignoredEdges: Edge.Set? = .bottom) {
+    init(
+        sheetColor: Color? = nil,
+        dragIndicator: DragIndicator = .init(),
+        detents: [Detent] = [.large],
+        cornerRadius: CGFloat = 20,
+        ignoredEdges: Edge.Set? = .bottom
+    ) {
         self.sheetColor = sheetColor
         self.dragIndicator = dragIndicator
-        self.detents = detents
+        self.cornerRadius = cornerRadius
         self.ignoredEdges = ignoredEdges
+        
+        var detents = detents
+
+        // Ensure there is always a detent present in `detents`
+        if detents.isEmpty {
+            assertionFailure("`detents` should always be populated")
+            detents.append(.large)
+        }
+        self.detents = detents
+
+        guard let smallestDetent = detents.min(by: { $0.fraction < $1.fraction }) else {
+            preconditionFailure("`smallestDetent` should never be nil")
+        }
+
+        self.selectedDetent = smallestDetent
     }
 }
 

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
@@ -16,7 +16,10 @@ class BottomSheetViewConfiguration {
     var cornerRadius: CGFloat
     /// Edges that ignore the safe area
     var ignoredEdges: Edge.Set
-    
+
+    /// Indicates if the bottom sheet's initial `selectedDetent` state has been set
+    var setInitialDetent = false
+
     init(
         sheetColor: Color? = nil,
         dragIndicator: DragIndicator = .init(),
@@ -38,8 +41,8 @@ class BottomSheetViewConfiguration {
         }
         self.detents = detents
 
-        guard let smallestDetent = detents.min(by: { $0.fraction < $1.fraction }) else {
-            preconditionFailure("`smallestDetent` should never be nil")
+        guard let smallestDetent = detents.smallest else {
+            preconditionFailure("`smallestDetent` should never be nil, based on the prior logic")
         }
 
         self.selectedDetent = smallestDetent

--- a/Sources/BottomSheet/Detent.swift
+++ b/Sources/BottomSheet/Detent.swift
@@ -30,3 +30,11 @@ public enum Detent {
         return detents.min(by: { abs($0.fraction - value) < abs($1.fraction - value) }) ?? .small
     }
 }
+
+extension Array where Element == Detent {
+
+    var smallest: Detent? {
+        self.min(by: { $0.fraction < $1.fraction })
+    }
+    
+}


### PR DESCRIPTION
Hi @wojtek717!

I was searching for a lightweight solution like your's yesterday. This is great, thank you for creating this package!

I started to experiment with your package in my app and caught a couple of issues.

## Permanently hidden `BottomSheetView`

I noticed that the `BottomSheetView` would sometimes get into a state where it was permanently hidden.

Before this PR:

https://github.com/user-attachments/assets/03151a6d-b8a1-4fa5-b177-91aa85cc96fb 

After this PR:

https://github.com/user-attachments/assets/ec543d40-aa8b-44ff-b827-1d7b57f2e3d9

## Selected `Detent`

Added the concept of a `selectedDetent`. This persists the bottom sheet's detent state when switching tabs. Also added support for selecting the initial detent of the bottom sheet, which defaults to the smallest detent.

Before this PR:

https://github.com/user-attachments/assets/cf71ee43-968c-406b-b0fc-263dd2d46564

After this PR:

https://github.com/user-attachments/assets/041fafe5-2a4e-4848-9f4e-655af4244ad6

## "Jumpy" drag gestures

When a user is doing a long drag gesture, sometimes the `translation`'s `height` evaluates to be some very large / small value. In this PR I smooth and clamp the drag gesture, to resolve this.

Before this PR: 

https://github.com/user-attachments/assets/a5f0ca89-da78-4fce-a92d-80d9256c256c

After this PR: 

https://github.com/user-attachments/assets/34a06838-efee-4994-b536-8de8560ea8d4

## Miscellaneous changes

I made `BottomSheetViewConfiguration` conform to `@Observable` and made it `@State` in `BottomSheetView` / `BottomSheet`. You previously had it as a `var` that would be updated by view modifiers. The only reason those changes would work is because the `sheetHeight` was being called frequently enabling the SwiftUI engine to check `BottomSheetViewConfiguration`'s new state.

I noticed you were adding `ViewBuilder` closures as instance properties, such as `@ViewBuilder private let content: () -> Content`, and that you were using `@escaping` in the initializer. This is considered bad practice, there can be unintended side effects. To learn more about this, I recommend reading [this](https://rensbr.eu/blog/swiftui-escaping-closures/) article! You can see the changes I made in `BottomSheet` that fix this.

Lastly, I did some general quality of life fixes like exposing `cornerRadius` for the sheet, naming improvements, and removed some forced view modifiers, such as the forced bottom safe area being ignored.

I may open a second PR with some other optional suggestions, but I wanted to keep my changes limited to what I saw as essential for the package.