### PR TITLE
Added support for `Binding<Detent>` and short term removed `isPresented`

### DIFF
--- a/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+detentsPresentation.swift
+++ b/Sources/BottomSheet/BottomSheet+Modifiers/BottomSheet+detentsPresentation.swift
@@ -8,13 +8,10 @@
 import SwiftUI
 
 public extension BottomSheet {
-    func detentsPresentation(initialDetent: Detent? = nil, detents: [Detent]) -> BottomSheet {
+
+    func detentsPresentation(detents: [Detent]) -> BottomSheet {
         configuration.detents = detents
-        if let initialDetent = initialDetent ?? detents.smallest, !configuration.setInitialDetent {
-            // Ensure this conditional is executed once
-            configuration.setInitialDetent = true
-            configuration.selectedDetent = initialDetent
-        }
         return self
     }
+
  }

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -13,13 +13,20 @@ struct BottomSheetView<Content: View>: View {
 
     @Binding private var configuration: BottomSheetViewConfiguration
 
+    @Binding private var selectedDetent: Detent
+
     private let content: Content
 
     /// Adjust this value to change the smoothing factor for on change drag gesture
     private let smoothingFactor: CGFloat = 0.2
 
-    init(configuration: Binding<BottomSheetViewConfiguration>, content: Content) {
+    init(
+        configuration: Binding<BottomSheetViewConfiguration>,
+        selectedDetent: Binding<Detent>,
+        content: Content
+    ) {
         self._configuration = configuration
+        self._selectedDetent = selectedDetent
         self.content = content
     }
     
@@ -47,7 +54,6 @@ struct BottomSheetView<Content: View>: View {
                     .onScrollGeometryChange(for: Double.self) { geometry in
                         return geometry.contentOffset.y
                     } action: { oldValue, newValue in
-                        print(newValue)
                         if newValue < 0.0 {
                             sheetHeight = max(
                                 minHeight(for: screenHeight),
@@ -62,7 +68,7 @@ struct BottomSheetView<Content: View>: View {
                             dragIndicator
                         }
                     })
-                    .frame(maxWidth: .infinity)
+                    .frame(minWidth: 0, maxWidth: .infinity)
                     .frame(height: sheetHeight)
                     .background(configuration.sheetColor)
                     .clipShape(
@@ -86,7 +92,7 @@ struct BottomSheetView<Content: View>: View {
                     )
             }
             .onAppear {
-                sheetHeight = configuration.selectedDetent.fraction * screenHeight
+                sheetHeight = selectedDetent.fraction * screenHeight
             }
         }.ignoresSafeArea(edges: configuration.ignoredEdges)
     }
@@ -137,8 +143,8 @@ extension BottomSheetView {
             return
         }
 
-        configuration.selectedDetent = selectedDetent
-        sheetHeight = desiredHeight
+        self.selectedDetent = selectedDetent
+        self.sheetHeight = desiredHeight
     }
 
     func minHeight(for screenHeight: CGFloat) -> CGFloat {

--- a/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetViewConfiguration.swift
@@ -11,27 +11,24 @@ import SwiftUI
 class BottomSheetViewConfiguration {
     var sheetColor: Color?
     var dragIndicator: DragIndicator
-    var selectedDetent: Detent
     var detents: [Detent]
     var cornerRadius: CGFloat
     /// Edges that ignore the safe area
     var ignoredEdges: Edge.Set
-
-    /// Indicates if the bottom sheet's initial `selectedDetent` state has been set
-    var setInitialDetent = false
 
     init(
         sheetColor: Color? = nil,
         dragIndicator: DragIndicator = .init(),
         detents: [Detent] = [.large],
         cornerRadius: CGFloat = 20,
-        ignoredEdges: Edge.Set = []
+        ignoredEdges: Edge.Set = [],
+        setInitialDetent: Bool = false
     ) {
         self.sheetColor = sheetColor
         self.dragIndicator = dragIndicator
         self.cornerRadius = cornerRadius
         self.ignoredEdges = ignoredEdges
-        
+
         var detents = detents
 
         // Ensure there is always a detent present in `detents`
@@ -40,12 +37,6 @@ class BottomSheetViewConfiguration {
             detents.append(.large)
         }
         self.detents = detents
-
-        guard let smallestDetent = detents.smallest else {
-            preconditionFailure("`smallestDetent` should never be nil, based on the prior logic")
-        }
-
-        self.selectedDetent = smallestDetent
     }
 }
 

--- a/Sources/BottomSheet/Detent.swift
+++ b/Sources/BottomSheet/Detent.swift
@@ -7,10 +7,11 @@
 
 import Foundation
 
-public enum Detent {
+public enum Detent: Equatable {
     case large
     case medium
     case small
+    case hidden
     case fraction(CGFloat)
     
     var fraction: CGFloat {
@@ -21,6 +22,8 @@ public enum Detent {
             return 0.50
         case .small:
             return 0.20
+        case .hidden:
+            return 0.0
         case .fraction(let value):
             return value
         }
@@ -36,5 +39,11 @@ extension Array where Element == Detent {
     var smallest: Detent? {
         self.min(by: { $0.fraction < $1.fraction })
     }
-    
+
+    var smallestExcludingHidden: Detent? {
+        var detents = self
+        detents.removeAll { $0 == .hidden }
+        return detents.smallest
+    }
+
 }


### PR DESCRIPTION
Stemming off of the discussion in #15 here is the implementation of `BottomSheet` _without_ `isPresented` and adding `selectedDetent` binding. As can be seen in `ExampleView`, the instantiator can determine `isPresented` by checking `selectedDetent != .hidden`.

_I am going to branch off of this PR to try and re-implement an `isPresented` binding, but the code complexity definitely spiked when I initially tried to include both. That being said, if Apple could do it for `sheet`, we can do it here. Leaving this as a draft PR in the meantime._

On my end - I really want to be able to determine the `selectedDetent` from the parent's context. I want to show a search bar / navigation bar, when the detent is `large` and hide those when it is not.

Demo video:

https://github.com/user-attachments/assets/b881fc11-1bd4-45b9-a0fc-70bf47000ec6
