### PR TITLE
Issue 25 - Updated scrolling logic

### DIFF
--- a/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
+++ b/Sources/BottomSheet/BottomSheetView/BottomSheetView.swift
@@ -18,7 +18,7 @@ struct BottomSheetView<Content: View>: View {
     private let content: Content
 
     /// Adjust this value to change the smoothing factor for on change drag gesture
-    private let smoothingFactor: CGFloat = 0.2
+    private let smoothingFactor: CGFloat = 0.1
 
     init(
         configuration: Binding<BottomSheetViewConfiguration>,

--- a/Sources/BottomSheet/Detent.swift
+++ b/Sources/BottomSheet/Detent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Detent: Equatable {
+public enum Detent: Equatable, Comparable {
     case large
     case medium
     case small
@@ -29,6 +29,10 @@ public enum Detent: Equatable {
         }
     }
     
+    public static func <(lhs: Detent, rhs: Detent) -> Bool {
+        return lhs.fraction < rhs.fraction
+    }
+
     static func forValue(_ value: CGFloat, from detents: [Detent]) -> Detent {
         return detents.min(by: { abs($0.fraction - value) < abs($1.fraction - value) }) ?? .small
     }
@@ -36,14 +40,12 @@ public enum Detent: Equatable {
 
 extension Array where Element == Detent {
 
-    var smallest: Detent? {
-        self.min(by: { $0.fraction < $1.fraction })
+    var largest: Detent? {
+        self.max(by: { $0 < $1 })
     }
 
-    var smallestExcludingHidden: Detent? {
-        var detents = self
-        detents.removeAll { $0 == .hidden }
-        return detents.smallest
+    var smallest: Detent? {
+        self.min(by: { $0 < $1 })
     }
 
 }


### PR DESCRIPTION
Addresses #25 

The scroll behavior wasn't working well on my physical device. I realized that the underlying `ScrollView` / `List` was conflicting with the `DragGesture`. Steps to reproduce an issue:

1. Scroll to the largest detent
2. Attempt to scroll down
3. Fails to scroll down on first attempt
4. Second attempt to scroll down works

Demo video of issue:

https://github.com/user-attachments/assets/1799e5d2-1aac-4a9f-9a0d-1199963fbdb6

The conflict between the `ScrollView` / `List` and the `DragGesture` can be addressed by making the `DragGesture` simultaneous using `simultaneousGesture`, but this came with it's own issues. Updating it to use `simultaneousGesture` meant that `scrollDisabled` wasn't working in it's current state. This led me down a path of updating the scroll logic to based on `contentOffset` and the `selectedDetent`.

Final result:

https://github.com/user-attachments/assets/2da220bc-6893-4955-bf6f-a06d700565b7
